### PR TITLE
Pin Tensorflow and Keras version numbers in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ After installing Miniconda, the following lines might are likely the easiest way
 ```
 $ conda create -n 'n2v' python=3.6
 $ source activate n2v
-$ conda install tensorflow-gpu keras
+$ conda install tensorflow-gpu=1.14 keras=2.2.4
 $ pip install jupyter
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ conda install tensorflow-gpu keras
 $ pip install jupyter
 ```
 
-Note: it is very important that the version of keras be 2.24 or 2.2.5, hence the explicit installation above.
+Note: it is very important that the version of keras be 2.2.4 or 2.2.5, hence the explicit installation above.
 Once this is done (or you had tensorflow et al. installed already), you can install N2V with one of the following two options:
 
 #### Option 1: PIP (current stable release)


### PR DESCRIPTION
The code in the README for creating the conda environment are not pinned to any specific version of Tensorflow and Keras, even though descriptions in the text above and below stress the importance of only using specific compatifble versions. I think it would be a smoother experience for new users if those versions were also pinned explicitly with conda.

Right now if you create a Python 3.6 conda environment and conda install tensorflow-gpu and keras into it unpinned (i.e. like the current code snippet in the readme) then you get Tensorflow version 2, which is incompatible with noise2void.

Note: it also seems like there might be a small typo in the sentence about the keras version number, should this read *"... version of keras be 2.2.4 or 2.2.5"* instead of *"... version of keras be 2.24 or 2.2.5"*?

Previous related issues: https://github.com/juglab/n2v/issues/39