### PR TITLE
fix bioimageio ci error on windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ isolated_build=true
 
 [testenv]
 passenv =
+    USERNAME
     CI
     GITHUB_ACTIONS
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
@@ -15,4 +16,4 @@ deps =
     tensorflow
 
 
-commands = pytest --ignore=tests/functional/ -m "not bioimage_io"
+commands = pytest --ignore=tests/functional/


### PR DESCRIPTION
Pass USERNAME in tox.ini to fix bioimage test failure on windows